### PR TITLE
[iamanager] Add aos-firewall service to block provision port

### DIFF
--- a/recipes-aos/aos-iamanager/aos-iamanager_git.bbappend
+++ b/recipes-aos/aos-iamanager/aos-iamanager_git.bbappend
@@ -1,11 +1,16 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+aos_firewall_srv:= "aos-firewall.service"
+iptables_rules_scr := "iptables-rules.sh"
+
 BRANCH = "master"
 
 SRC_URI_append = "\
     file://aos-iamanager.service \
     file://aos_iamanager.cfg \
     file://finish.sh \
+    file://${aos_firewall_srv} \
+    file://${iptables_rules_scr} \
 "
 
 AOS_IAM_CERT_MODULES = "\
@@ -19,11 +24,14 @@ AOS_IAM_IDENT_MODULES = "\
 inherit systemd
 
 SYSTEMD_SERVICE_${PN} = "aos-iamanager.service"
+SYSTEMD_SERVICE_${PN} += " ${aos_firewall_srv}"
 
 FILES_${PN} += " \
     ${sysconfdir}/aos/aos_iamanager.cfg \
     ${systemd_system_unitdir}/aos-iamanager.service \
     /var/aos/finish.sh \
+    ${systemd_system_unitdir}/${aos_firewall_srv} \
+    ${bindir}/${iptables_rules_scr} \
 "
 
 do_install_append() {
@@ -35,4 +43,9 @@ do_install_append() {
 
     install -d ${D}/var/aos/iamanager
     install -m 0755 ${WORKDIR}/finish.sh ${D}/var/aos/finish.sh
+
+    install -m 0644 /dev/null ${D}/var/aos/unprovisioned_state
+
+    install -D -m 0644 ${WORKDIR}/${aos_firewall_srv} ${D}${systemd_system_unitdir}
+    install -D -m 0744 ${WORKDIR}/${iptables_rules_scr} ${D}${bindir}
 }

--- a/recipes-aos/aos-iamanager/files/aos-firewall.service
+++ b/recipes-aos/aos-iamanager/files/aos-firewall.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=aos-firewall 
+Before=network-pre.target
+After=iptables.service
+Wants=network-pre.target
+ConditionPathExists=!/var/aos/unprovisioned_state
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/iptables-rules.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-aos/aos-iamanager/files/finish.sh
+++ b/recipes-aos/aos-iamanager/files/finish.sh
@@ -1,3 +1,4 @@
 # !/bin/sh
 
-systemctl restart aos.target
+rm -rf /var/aos/unprovisioned_state
+systemctl restart aos-firewall

--- a/recipes-aos/aos-iamanager/files/iptables-rules.sh
+++ b/recipes-aos/aos-iamanager/files/iptables-rules.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+iptables -A INPUT -p tcp --dport 8089 -j DROP
+iptables -A INPUT -p udp --dport 8089 -j DROP


### PR DESCRIPTION
Add aos-firewall.service which checks for /var/aos/unprovisioned_state
file. If file not exists - service do not start and don't block 8089
ports.
IAM manager after provisioning should remove
/var/aos/unprovisioned_state file and restart aos-firewall.service.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>